### PR TITLE
fix: 가변 다이나믹 서브셋 버전으로 교체, 전역 적용

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,24 +4,15 @@
 
 @layer base {
   /* reset.css의 확장 */
-  /* h1{}
-  h2{} */
   @font-face {
-    font-family: "Pretendard-Regular";
-    src: url("https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff")
-      format("woff");
-    font-weight: 400;
+    font-family: "Pretendard Variable";
+    src: url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css");
     font-style: normal;
   }
   :root {
     font-size: 62.5%;
-    font-family: pretendard
+    font-family: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
   }
-  
-
-  /* html {
-    font-family: Pretendard-Regular;
-  } */
 }
 
 @layer components {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -122,7 +122,7 @@ const config: Config = {
 		extend: {
 			fontFamily: {
 				// 예시) <p className="text-pretendard">
-				pretendard: ['Pretendard-Regular'],
+				pretendard: ['Pretendard Variable'],
 			},
 			colors: {
 				// 예시) <p className="bg-gray-D">


### PR DESCRIPTION
## 어떤 변경인지

- [ ] feat: 기능 변경, 기능 추가
- [x] fix: 버그 수정
- [ ] design: css만 수정
- [ ] refactor: 동작 변경 없는 수정
- [ ] style: 내용 변경 없는 수정 (린트, 포맷 변경 등)
- [ ] build: src 외부 코드 수정
- [ ] remove: 파일 삭제 
- [ ] docs: 문서 작업 (README, pr 템플릿)

## 설명
> pr 내용을 간략히 설명해주세요.
https://github.com/orioncactus/pretendard
- 폰트 출처 눈누 폰트 → 프리텐다드 공식 깃헙으로 변경
- 가변 다이내믹 서브셋 버전으로 적용
- global.css에서 font-family 지정 

### 이슈 번호

> 예) .../codeit-top-secret-X/issues/[이슈번호]
> https://github.com/sozign/codeit-top-secret-X/issues/25

### To Reviewers
close #25 