### PR TITLE
Feat: z-index 추가 및 ConfirmModal (삭제 확인 모달) 구현

### DIFF
--- a/src/components/common/Headers/DashboardHeader.tsx
+++ b/src/components/common/Headers/DashboardHeader.tsx
@@ -133,7 +133,7 @@ export default function DashboardHeader({ dashboardId, title }: HeaderNavProps) 
 
 	return (
 		<>
-			<header className='container sticky inset-0 flex h-[7rem]  flex-row items-center justify-between border-b-[0.1rem] border-gray-D   bg-white pl-[2rem] sm:h-[6rem] sm:pl-0'>
+			<header className='container sticky inset-0 z-HEADER flex h-[7rem] flex-row items-center justify-between border-b-[0.1rem] border-gray-D bg-white pl-[2rem] sm:h-[6rem] sm:pl-0'>
 				{router.pathname.startsWith('/mypage') ? (
 					<div className='container flex flex-row gap-[0.4rem]  text-20-700 text-black-3'>
 						<span className='md:hidden sm:hidden'>{dashboardInfo.title ? dashboardInfo.title : title}</span>

--- a/src/components/common/Headers/LandingHeader.tsx
+++ b/src/components/common/Headers/LandingHeader.tsx
@@ -5,7 +5,7 @@ import Taskify from '@/../../Public/assets/Taskify.svg';
 
 export default function LandingHeader() {
 	return (
-		<header className='container flex flex-row items-center justify-between pb-[1.5rem] pl-[1.6rem] pt-[1.6rem]'>
+		<header className='container z-HEADER flex flex-row items-center justify-between pb-[1.5rem] pl-[1.6rem] pt-[1.6rem]'>
 			<Link href='/' className='inline-flex  items-center justify-center pl-[0.4rem] pr-[0.4rem] pt-[0.4rem]'>
 				<div className='flex h-[3.5rem] items-center justify-end pb-[0.1931rem] pl-[0.6202rem] '>
 					<Image alt='TaskifyImage' src={TaskifyImage} className='h-[3.3069rem] w-[2.8797rem]' />

--- a/src/components/domains/edit/Invitation.tsx
+++ b/src/components/domains/edit/Invitation.tsx
@@ -1,6 +1,8 @@
 import { InvitationDashboardData } from '@/constants/types';
 import Button from '../../common/Buttons/Button';
 import { deleteInvitationDashboard } from '@/lib/api';
+import { useState } from 'react';
+import Layout from '@/components/modal/Layout';
 
 interface InvitationProps {
 	invitationData: InvitationDashboardData;
@@ -8,25 +10,50 @@ interface InvitationProps {
 }
 
 function Invitation({ invitationData, dashboardId }: InvitationProps) {
+	const [isModalOpen, setIsModalOpen] = useState(false);
+
 	async function handleDeleteMember(dashboardId: number, invitationId: number) {
 		await deleteInvitationDashboard(dashboardId, invitationId);
 	}
 
 	return (
-		<div className='flex h-[3.8rem] w-full items-center justify-between sm:h-[3.4rem]'>
-			<div className='flex items-center'>
-				<div className='flex text-16-400 text-black-3 sm:text-14-400'>{invitationData.invitee.email}</div>
+		<>
+			<div className='flex h-[3.8rem] w-full items-center justify-between sm:h-[3.4rem]'>
+				<div className='flex items-center'>
+					<div className='flex text-16-400 text-black-3 sm:text-14-400'>{invitationData.invitee.email}</div>
+				</div>
+				<Button
+					disabled={false}
+					onClick={() => setIsModalOpen(true)}
+					color='white'
+					variant='delete-lg'
+					className='cursor-pointer sm:w-[5.2rem] sm:text-12-500'
+				>
+					취소
+				</Button>
 			</div>
-			<Button
-				disabled={false}
-				onClick={() => handleDeleteMember(dashboardId, invitationData.id)}
-				color='white'
-				variant='delete-lg'
-				className='cursor-pointer sm:w-[5.2rem] sm:text-12-500'
-			>
-				취소
-			</Button>
-		</div>
+			{isModalOpen && (
+				<Layout isOpen={isModalOpen} setOpen={setIsModalOpen} $modalType='Alert'>
+					<div className='flex w-full flex-col items-center justify-between gap-[4.5rem] text-18-500 sm:text-14-500'>
+						<div className='h-[1rem] w-full' />
+						초대를 취소하시겠습니까?
+						<div className='flex w-full justify-end gap-[1.2rem] sm:justify-center sm:gap-[1.1rem]'>
+							<Button disabled={false} onClick={() => setIsModalOpen(false)} color='modalWhite' variant='modal'>
+								취소
+							</Button>
+							<Button
+								disabled={false}
+								onClick={() => handleDeleteMember(dashboardId, invitationData.id)}
+								color='modalViolet'
+								variant='modal'
+							>
+								확인
+							</Button>
+						</div>
+					</div>
+				</Layout>
+			)}
+		</>
 	);
 }
 

--- a/src/components/domains/edit/InvitationsBox.tsx
+++ b/src/components/domains/edit/InvitationsBox.tsx
@@ -62,7 +62,9 @@ function InvitationsBox({ dashboardId, invitations, paginationInfo, setPaginatio
 					</div>
 				)}
 			</div>
-			<InviteModal isOpen={isInviteModalOpen} setIsOpen={setIsInviteModalOpen} dashboardId={dashboardId} />
+			{isInviteModalOpen && (
+				<InviteModal isOpen={isInviteModalOpen} setIsOpen={setIsInviteModalOpen} dashboardId={dashboardId} />
+			)}
 		</>
 	);
 }

--- a/src/components/domains/edit/Member.tsx
+++ b/src/components/domains/edit/Member.tsx
@@ -3,6 +3,8 @@ import Image from 'next/image';
 import Button from '../../common/Buttons/Button';
 import { deleteMembers } from '@/lib/api';
 import Crown from '@/../../Public/assets/royalCrownIcon.svg';
+import { useState } from 'react';
+import ConfirmModal from '@/components/modal/ConfirmModal';
 
 interface MemberProps {
 	memberData: MembersData;
@@ -10,40 +12,53 @@ interface MemberProps {
 }
 
 function Member({ hostId, memberData }: MemberProps) {
+	const [isMemberDeleteModalOpen, setIsMemberDeleteModalOpen] = useState(false);
+
 	async function handleDeleteMember(memberId: number) {
 		await deleteMembers(memberId);
 	}
 
 	return (
-		<div className='flex h-[3.8rem] w-full items-center justify-between sm:h-[3.4rem]'>
-			<div className='flex items-center gap-[1.2rem] sm:gap-[0.8rem]'>
-				<div className='flex h-[3.8rem] w-[3.8rem] rounded-full sm:h-[3.4rem] sm:w-[3.4rem]'>
-					{memberData.profileImageUrl ? (
-						<Image src={memberData.profileImageUrl} alt='프로필 이미지' width={38} height={38} />
-					) : (
-						<div className='flex w-full items-center justify-center rounded-full bg-green'>
-							<span className='sm:text-14-600 text-center text-16-600'>{memberData.nickname.slice(0, 1)}</span>
-						</div>
-					)}
+		<>
+			<div className='flex h-[3.8rem] w-full items-center justify-between sm:h-[3.4rem]'>
+				<div className='flex items-center gap-[1.2rem] sm:gap-[0.8rem]'>
+					<div className='flex h-[3.8rem] w-[3.8rem] rounded-full sm:h-[3.4rem] sm:w-[3.4rem]'>
+						{memberData.profileImageUrl ? (
+							<Image src={memberData.profileImageUrl} alt='프로필 이미지' width={38} height={38} />
+						) : (
+							<div className='flex w-full items-center justify-center rounded-full bg-green'>
+								<span className='sm:text-14-600 text-center text-16-600'>{memberData.nickname.slice(0, 1)}</span>
+							</div>
+						)}
+					</div>
+					<span className='text-16-400 sm:text-14-400'>{memberData.nickname}</span>
 				</div>
-				<span className='text-16-400 sm:text-14-400'>{memberData.nickname}</span>
+				{hostId === memberData.userId ? (
+					<div className='flex w-[8.4rem] justify-center'>
+						<Image src={Crown} alt='대시보드 주인 왕관' height={32} />
+					</div>
+				) : (
+					<Button
+						onClick={() => setIsMemberDeleteModalOpen(true)}
+						disabled={false}
+						color='white'
+						variant='delete-lg'
+						className='sm:w-[5.2rem] sm:text-12-500'
+					>
+						삭제
+					</Button>
+				)}
 			</div>
-			{hostId === memberData.userId ? (
-				<div className='flex w-[8.4rem] justify-center'>
-					<Image src={Crown} alt='대시보드 주인 왕관' height={32} />
-				</div>
-			) : (
-				<Button
-					onClick={() => handleDeleteMember(memberData.id)}
-					disabled={false}
-					color='white'
-					variant='delete-lg'
-					className='sm:w-[5.2rem] sm:text-12-500'
-				>
-					삭제
-				</Button>
+			{isMemberDeleteModalOpen && (
+				<ConfirmModal
+					content='대시보드 구성원을 삭제하시겠습니까?'
+					isOpen={isMemberDeleteModalOpen}
+					setOpen={setIsMemberDeleteModalOpen}
+					request={handleDeleteMember}
+					id={memberData.id}
+				/>
 			)}
-		</div>
+		</>
 	);
 }
 

--- a/src/components/modal/ColumnsEditModal.tsx
+++ b/src/components/modal/ColumnsEditModal.tsx
@@ -1,11 +1,11 @@
-import { putColumn } from '@/lib/api';
+import { deleteColumn, putColumn } from '@/lib/api';
+import { useRouter } from 'next/router';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { FieldErrors, SubmitHandler, useForm } from 'react-hook-form';
 import Button from '../common/Buttons/Button';
 import FormInput from '../common/Input/FormInput';
+import ConfirmModal from './ConfirmModal';
 import Layout from './Layout';
-import ColumnsDeletedModal from './ColumnsDeletedModal';
-import { useRouter } from 'next/router';
 
 interface ModalProps {
 	isOpen: boolean;
@@ -28,7 +28,7 @@ function ColumnsEditModal({ isOpen, setIsOpen, columnId }: ModalProps) {
 			title: '',
 		},
 	});
-	const [columnsDeletedModalOpen, setColumnsDeletedModalOpen] = useState(false);
+	const [isColumnsDeletedModalOpen, setIsColumnsDeletedModalOpen] = useState(false);
 	const [columnsTitleState, setColumnsTitleState] = useState({
 		title: '',
 		id: 0,
@@ -67,8 +67,8 @@ function ColumnsEditModal({ isOpen, setIsOpen, columnId }: ModalProps) {
 					<div className='flex flex-row justify-between sm:flex-col sm:items-start sm:gap-[1.6rem]'>
 						<div
 							onClick={() => {
-								setIsOpen(false);
-								setColumnsDeletedModalOpen(true);
+								// setIsOpen(false);
+								setIsColumnsDeletedModalOpen(true);
 							}}
 							className=' flex cursor-pointer flex-row items-end justify-end border-b-[0.1rem] border-gray-9 text-14-400 text-gray-9'
 						>
@@ -92,11 +92,15 @@ function ColumnsEditModal({ isOpen, setIsOpen, columnId }: ModalProps) {
 					</div>
 				</form>
 			</Layout>
-			<ColumnsDeletedModal
-				isOpen={columnsDeletedModalOpen}
-				setIsOpen={setColumnsDeletedModalOpen}
-				columnId={columnId}
-			/>
+			{isColumnsDeletedModalOpen && (
+				<ConfirmModal
+					request={deleteColumn}
+					content='컬럼의 모든 카드가 삭제 됩니다.'
+					isOpen={isColumnsDeletedModalOpen}
+					setOpen={setIsColumnsDeletedModalOpen}
+					id={columnId}
+				/>
+			)}
 		</>
 	);
 }

--- a/src/components/modal/ConfirmModal.tsx
+++ b/src/components/modal/ConfirmModal.tsx
@@ -1,0 +1,41 @@
+import { Dispatch, SetStateAction } from 'react';
+import Button from '../common/Buttons/Button';
+import Layout from './Layout';
+import { useRouter } from 'next/router';
+
+interface ConfirmModalProps {
+	isOpen: boolean;
+	setOpen: Dispatch<SetStateAction<boolean>>;
+	content: string;
+	id: number;
+	request: (id: number) => Promise<number | void>;
+	reload?: () => Promise<void>;
+}
+
+function ConfirmModal({ isOpen, setOpen, id, content, reload, request }: ConfirmModalProps) {
+	const router = useRouter();
+	async function handleConfirm(id: number) {
+		const status = await request(id);
+		console.log(status);
+		if (reload) await reload();
+		else router.reload();
+	}
+	return (
+		<Layout isOpen={isOpen} setOpen={setOpen} $modalType='Alert'>
+			<div className='flex w-full flex-col items-center justify-between gap-[4.5rem] text-18-500 sm:text-14-500'>
+				<div className='h-[1rem] w-full' />
+				{content}
+				<div className='flex w-full justify-end gap-[1.2rem] sm:justify-center sm:gap-[1.1rem]'>
+					<Button disabled={false} onClick={() => setOpen(false)} color='modalWhite' variant='modal'>
+						취소
+					</Button>
+					<Button disabled={false} onClick={() => handleConfirm(id)} color='modalViolet' variant='modal'>
+						확인
+					</Button>
+				</div>
+			</div>
+		</Layout>
+	);
+}
+
+export default ConfirmModal;

--- a/src/components/modal/Layout.tsx
+++ b/src/components/modal/Layout.tsx
@@ -20,7 +20,7 @@ function Layout({ children, $modalType, title, isOpen, setOpen }: LayoutProps) {
 
 	return createPortal(
 		<div
-			className='overlay fixed left-0 top-0 z-MODALLAYOUT flex h-full w-full items-center justify-center bg-black-0/70'
+			className='overlay fixed left-0 top-0 z-MODALLAYOUT flex h-full w-full items-center justify-center bg-black-0/50'
 			onClick={() => setOpen((prev) => !prev)}
 		>
 			<div

--- a/src/components/modal/Layout.tsx
+++ b/src/components/modal/Layout.tsx
@@ -20,11 +20,11 @@ function Layout({ children, $modalType, title, isOpen, setOpen }: LayoutProps) {
 
 	return createPortal(
 		<div
-			className='overlay fixed left-0 top-0 flex h-full w-full items-center justify-center bg-black-0/70'
+			className='overlay fixed left-0 top-0 z-MODALLAYOUT flex h-full w-full items-center justify-center bg-black-0/70'
 			onClick={() => setOpen((prev) => !prev)}
 		>
 			<div
-				className={`modal relative z-10 ${modalType[$modalType]}`}
+				className={`modal relative z-MODAL ${modalType[$modalType]}`}
 				onClick={(e) => {
 					e.stopPropagation();
 				}}

--- a/src/components/modal/TaskModal.tsx
+++ b/src/components/modal/TaskModal.tsx
@@ -7,7 +7,8 @@ import Avatar from '../common/Avatar';
 import StatusChip from '../common/chips/StatusChip';
 import TagChip from '../common/chips/TagChip';
 import { CardData, CommentPost, CommentData } from '@/constants/types';
-import { getComments, postComment } from '@/lib/api';
+import { deleteCardItem, getComments, postComment } from '@/lib/api';
+import ConfirmModal from './ConfirmModal';
 
 interface TaskModalProps {
 	taskModalControl: {
@@ -81,6 +82,9 @@ export default function TaskModal({ taskModalControl, editModalControl, cardItem
 		}
 	};
 
+	// 태스크 카드 삭제하기 모달 관련
+	const [isTaskCardDeleteModalOpen, setIsTaskCardDeleteModalOpen] = useState(false);
+
 	return (
 		<Layout
 			$modalType='Task'
@@ -110,10 +114,22 @@ export default function TaskModal({ taskModalControl, editModalControl, cardItem
 									>
 										수정하기
 									</button>
-									<button className='h-[3.2rem] w-full items-center justify-center rounded-[0.4rem] text-14-400 text-black-3 hover:bg-violet-F hover:text-violet-5'>
+									<button
+										onClick={() => setIsTaskCardDeleteModalOpen(true)}
+										className='h-[3.2rem] w-full items-center justify-center rounded-[0.4rem] text-14-400 text-black-3 hover:bg-violet-F hover:text-violet-5'
+									>
 										삭제하기
 									</button>
 								</ul>
+							)}
+							{isTaskCardDeleteModalOpen && (
+								<ConfirmModal
+									request={deleteCardItem}
+									id={cardItem.id}
+									isOpen={isTaskCardDeleteModalOpen}
+									setOpen={setIsTaskCardDeleteModalOpen}
+									content='카드를 삭제하시겠습니까?'
+								/>
 							)}
 						</div>
 						<button

--- a/src/pages/dashboard/[boardid]/edit.tsx
+++ b/src/pages/dashboard/[boardid]/edit.tsx
@@ -4,6 +4,7 @@ import PageLayout from '@/components/common/PageLayout';
 import EditBox from '@/components/domains/edit/EditBox';
 import InvitationsBox from '@/components/domains/edit/InvitationsBox';
 import MemberBox from '@/components/domains/edit/MemberBox';
+import ConfirmModal from '@/components/modal/ConfirmModal';
 import { DashboardData, InvitationsDashboardGet, MembersGet, UserInfo } from '@/constants/types';
 import {
 	deleteDashboard,
@@ -22,6 +23,7 @@ export default function DashBoardEdit() {
 	const router = useRouter();
 	const boardId = +(router.query.boardid ?? 0);
 
+	const [isDashboardDeleteConfirmModalOpen, setIsDashboardDeleteConfirmModalOpen] = useState(false);
 	const [dashboardInfo, setDashboardInfo] = useState<DashboardData>({
 		id: boardId,
 		title: '',
@@ -95,6 +97,7 @@ export default function DashBoardEdit() {
 	}
 
 	useEffect(() => {
+		if (boardId === 0) return;
 		loadDashboardData(boardId);
 		loadMyInfo();
 		setMembersPagination({ dashboardId: boardId, page: 1, size: 4 });
@@ -102,6 +105,7 @@ export default function DashBoardEdit() {
 	}, [boardId]);
 
 	useEffect(() => {
+		if (membersPagination.dashboardId === 0 || invitationsPagination.dashboardId === 0) return;
 		loadDashboardMembersData(membersPagination);
 		loadInvitationsDashboardData(invitationsPagination);
 	}, [membersPagination, invitationsPagination]);
@@ -112,43 +116,54 @@ export default function DashBoardEdit() {
 	}
 
 	return (
-		<PageLayout boardId={boardId}>
-			<div className='flex h-fit min-h-full w-full flex-col gap-[2rem] bg-gray-F pb-[5.6rem] md:pb-[4.8rem] sm:gap-[1.7rem] sm:pb-[2.4rem]'>
-				<DashboardHeader dashboardId={boardId} title={''} />
-				<Link
-					href={`/dashboard/${boardId}`}
-					className='ml-[2rem] flex h-fit w-fit items-center justify-center gap-[0.6rem]'
-				>
-					<Image src={arrowForward} alt='돌아가기 버튼' className='sm:h-[1.8rem] sm:w-[1.8rem]' />
-					<span className='text-16-500 text-black-3 sm:text-14-500'>돌아가기</span>
-				</Link>
-				<div className='flex flex-col gap-[1.2rem] px-[2.8rem] sm:gap-[1.1rem]'>
-					<EditBox
-						loadDashboardData={loadDashboardData}
-						dashboardId={boardId}
-						title={dashboardInfo.title}
-						color={dashboardInfo.color}
-					/>
-					<MemberBox
-						hostId={dashboardInfo.userId}
-						members={members}
-						paginationInfo={membersPagination}
-						setPaginationInfo={setMembersPagination}
-					/>
-					<InvitationsBox
-						dashboardId={boardId}
-						paginationInfo={invitationsPagination}
-						setPaginationInfo={setInvitationsPagination}
-						invitations={invitationsDashboard}
-					/>
-					<button
-						onClick={() => handleDelete(boardId)}
-						className='flex  h-[6.2rem]  w-[32.5rem]  items-center justify-center rounded-[0.8rem]  border border-gray-D bg-gray-F text-18-500 text-black-3 sm:w-[100%] sm:text-16-500'
+		<>
+			<PageLayout boardId={boardId}>
+				<div className='flex h-fit min-h-full w-full flex-col gap-[2rem] bg-gray-F pb-[5.6rem] md:pb-[4.8rem] sm:gap-[1.7rem] sm:pb-[2.4rem]'>
+					<DashboardHeader dashboardId={boardId} title={''} />
+					<Link
+						href={`/dashboard/${boardId}`}
+						className='ml-[2rem] flex h-fit w-fit items-center justify-center gap-[0.6rem]'
 					>
-						<div>대시보드 삭제하기</div>
-					</button>
+						<Image src={arrowForward} alt='돌아가기 버튼' className='sm:h-[1.8rem] sm:w-[1.8rem]' />
+						<span className='text-16-500 text-black-3 sm:text-14-500'>돌아가기</span>
+					</Link>
+					<div className='flex flex-col gap-[1.2rem] px-[2.8rem] sm:gap-[1.1rem]'>
+						<EditBox
+							loadDashboardData={loadDashboardData}
+							dashboardId={boardId}
+							title={dashboardInfo.title}
+							color={dashboardInfo.color}
+						/>
+						<MemberBox
+							hostId={dashboardInfo.userId}
+							members={members}
+							paginationInfo={membersPagination}
+							setPaginationInfo={setMembersPagination}
+						/>
+						<InvitationsBox
+							dashboardId={boardId}
+							paginationInfo={invitationsPagination}
+							setPaginationInfo={setInvitationsPagination}
+							invitations={invitationsDashboard}
+						/>
+						<button
+							onClick={() => setIsDashboardDeleteConfirmModalOpen(true)}
+							className='flex h-[6.2rem] w-[32.5rem] items-center justify-center rounded-[0.8rem]  border border-gray-D bg-gray-F text-18-500 text-black-3 sm:w-[100%] sm:text-16-500'
+						>
+							<div>대시보드 삭제하기</div>
+						</button>
+					</div>
 				</div>
-			</div>
-		</PageLayout>
+			</PageLayout>
+			{isDashboardDeleteConfirmModalOpen && (
+				<ConfirmModal
+					content='대시보드를 삭제하시겠습니까?'
+					id={boardId}
+					isOpen={isDashboardDeleteConfirmModalOpen}
+					setOpen={setIsDashboardDeleteConfirmModalOpen}
+					request={handleDelete}
+				/>
+			)}
+		</>
 	);
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -265,6 +265,13 @@ const config: Config = {
 					D: '#D25B68',
 				},
 			},
+			zIndex: {
+				HEADER: '1',
+				MODALLAYOUT: '2',
+				MODAL: '3',
+				NESTEDMODALLAYOUT: '4',
+				NESTEDMODAL: '5',
+			},
 		},
 	},
 	plugins: [],


### PR DESCRIPTION
## 어떤 변경인지

- [x] feat: 기능 변경, 기능 추가
- [ ] fix: 버그 수정
- [ ] design: css만 수정
- [ ] refactor: 동작 변경 없는 수정
- [ ] style: 내용 변경 없는 수정 (린트, 포맷 변경 등)
- [ ] build: src 외부 코드 수정
- [ ] remove: 파일 삭제 
- [ ] docs: 문서 작업 (README, pr 템플릿)

## 설명
> 대시보드 수정 페이지의 멤버 삭제, 초대 취소, 대시보드 삭제 시 ConfirmModal 띄움
> 컬럼 삭제 시 ConfirmModal 띄움
> 카드 삭제 시 ConfirmModal 띄움
> 댓글 삭제 시 ConfirmModal 아직 안 띄움..

> ConfirmModalProps ? 
> id: 삭제할 타겟의 아이디
> request: 삭제할 때 요청할 api 함수
> reload: 예를 들어 멤버를 삭제한다면 상위 컴포넌트에서 멤버목록을 다시 load 하는 함수를 넣어주면 됩니다. reload 생략 시 router.reload() 함수로 페이지 새로고침

### 이슈 번호

> 예) .../codeit-top-secret-X/issues/[이슈번호]
> https://github.com/sozign/codeit-top-secret-X/issues/142

### To Reviewers
close #142 
